### PR TITLE
ユーザー単体取得APIの追加

### DIFF
--- a/src/controller/users.ts
+++ b/src/controller/users.ts
@@ -1,5 +1,4 @@
 import {Interactor} from "../usecase/users/endpoint"
-import {ListOutput} from "../usecase/users/output";
 import express from "express";
 import {GetInput} from "../usecase/users/input";
 
@@ -8,9 +7,9 @@ export class usersController {
     constructor(interactor: Interactor) {
         this.interactor = interactor;
     }
-    // TODO コントローラーで express.res.json するように変更
-    async GetList():Promise<ListOutput> {
-        return this.interactor.GetList();
+    async GetList(req: express.Request, res: express.Response) {
+        const data = await this.interactor.GetList();
+        res.status(200).json(data);
     }
     async Get(req: express.Request, res: express.Response) {
         const stringParam = req.params.id;

--- a/src/controller/users.ts
+++ b/src/controller/users.ts
@@ -1,12 +1,28 @@
 import {Interactor} from "../usecase/users/endpoint"
 import {ListOutput} from "../usecase/users/output";
+import express from "express";
+import {GetInput} from "../usecase/users/input";
+
 
 export class usersController {
     protected interactor: Interactor;
     constructor(interactor: Interactor) {
         this.interactor = interactor;
     }
+    // TODO コントローラーで express.res.json するように変更
     async GetList():Promise<ListOutput> {
         return this.interactor.GetList();
+    }
+    async Get(req: express.Request, res: express.Response) {
+        const stringParam = req.params.id;
+        const input: GetInput = {
+            userID: Number(stringParam)
+        };
+        const data = await this.interactor.Get(input);
+        if (data.isFailure()) {
+            res.status(400).json(data.value);
+        } else {
+            res.status(200).json(data.value);
+        }
     }
 }

--- a/src/controller/users.ts
+++ b/src/controller/users.ts
@@ -3,7 +3,6 @@ import {ListOutput} from "../usecase/users/output";
 import express from "express";
 import {GetInput} from "../usecase/users/input";
 
-
 export class usersController {
     protected interactor: Interactor;
     constructor(interactor: Interactor) {

--- a/src/domain/users.ts
+++ b/src/domain/users.ts
@@ -5,11 +5,11 @@ import {resourceNotFoundError} from "../errorTypes/errors";
 
 export interface Repository {
     GetList(prisma: PrismaClient):Promise<User[]>;
-    Get(prisma: PrismaClient, userID: number):Promise<Result<User, resourceNotFoundError>>;
+    Get(prisma: PrismaClient, userID: number):Promise<Result<user, resourceNotFoundError>>;
 }
 
-// export type user = {
-//     ID: number
-//     email: string
-//     name: string
-// }
+export type user = {
+    ID: number
+    email: string
+    name: string
+}

--- a/src/domain/users.ts
+++ b/src/domain/users.ts
@@ -3,6 +3,7 @@ import {User} from "@prisma/client"
 
 export interface Repository {
     GetList(prisma: PrismaClient):Promise<User[]>;
+    Get(prisma: PrismaClient, userID: number):Promise<Promise<User> | null>;
 }
 
 // export type user = {

--- a/src/domain/users.ts
+++ b/src/domain/users.ts
@@ -11,5 +11,5 @@ export interface Repository {
 export type user = {
     ID: number
     email: string
-    name: string
+    name: string | null
 }

--- a/src/domain/users.ts
+++ b/src/domain/users.ts
@@ -3,7 +3,7 @@ import {User} from "@prisma/client"
 
 export interface Repository {
     GetList(prisma: PrismaClient):Promise<User[]>;
-    Get(prisma: PrismaClient, userID: number):Promise<Promise<User> | null>;
+    Get(prisma: PrismaClient, userID: number):Promise<Result<User, notfoundError>>;
 }
 
 // export type user = {

--- a/src/domain/users.ts
+++ b/src/domain/users.ts
@@ -1,5 +1,7 @@
 import {PrismaClient} from "@prisma/client";
 import {User} from "@prisma/client"
+import {Result} from "../errorTypes/resultType";
+import {resourceNotFoundError} from "../errorTypes/errors";
 
 export interface Repository {
     GetList(prisma: PrismaClient):Promise<User[]>;

--- a/src/domain/users.ts
+++ b/src/domain/users.ts
@@ -3,7 +3,7 @@ import {User} from "@prisma/client"
 
 export interface Repository {
     GetList(prisma: PrismaClient):Promise<User[]>;
-    Get(prisma: PrismaClient, userID: number):Promise<Result<User, notfoundError>>;
+    Get(prisma: PrismaClient, userID: number):Promise<Result<User, resourceNotFoundError>>;
 }
 
 // export type user = {

--- a/src/domain/users.ts
+++ b/src/domain/users.ts
@@ -1,10 +1,9 @@
 import {PrismaClient} from "@prisma/client";
-import {User} from "@prisma/client"
 import {Result} from "../errorTypes/resultType";
 import {resourceNotFoundError} from "../errorTypes/errors";
 
 export interface Repository {
-    GetList(prisma: PrismaClient):Promise<User[]>;
+    GetList(prisma: PrismaClient):Promise<user[]>;
     Get(prisma: PrismaClient, userID: number):Promise<Result<user, resourceNotFoundError>>;
 }
 

--- a/src/errorTypes/errors.ts
+++ b/src/errorTypes/errors.ts
@@ -1,10 +1,12 @@
-class resourceNotFoundError extends Error {
-    private readonly resource: string;
+class resourceNotFoundError extends Error{
+    message: string;
+    name: string;
     constructor(resource: string) {
         super();
-        this.resource = resource;
+        this.message = resource;
+        this.name = "resourceNotFoundError"
     }
     CatError = () => {
-        return this.resource + "not found"
+        return this.message + "not found"
     }
 }

--- a/src/errorTypes/errors.ts
+++ b/src/errorTypes/errors.ts
@@ -1,1 +1,10 @@
-class notfoundError extends Error {}
+class resourceNotFoundError extends Error {
+    private readonly resource: string;
+    constructor(resource: string) {
+        super();
+        this.resource = resource;
+    }
+    CatError = () => {
+        return this.resource + "not found"
+    }
+}

--- a/src/errorTypes/errors.ts
+++ b/src/errorTypes/errors.ts
@@ -1,0 +1,1 @@
+class notfoundError extends Error {}

--- a/src/errorTypes/errors.ts
+++ b/src/errorTypes/errors.ts
@@ -1,4 +1,4 @@
-class resourceNotFoundError extends Error{
+export class resourceNotFoundError extends Error{
     message: string;
     name: string;
     constructor(resource: string) {

--- a/src/errorTypes/resultType.ts
+++ b/src/errorTypes/resultType.ts
@@ -1,6 +1,8 @@
-type Result<T, E> = Success<T, E> | Failure<T, E>
+import exp from "constants";
 
-class Success<T, E> {
+export type Result<T, E> = Success<T, E> | Failure<T, E>
+
+export class Success<T, E> {
     constructor(readonly value: T) {}
     type = 'success' as const
     isSuccess(): this is Success<T, E> {
@@ -11,7 +13,7 @@ class Success<T, E> {
     }
 }
 
-class Failure<T, E> {
+export class Failure<T, E> {
     constructor(readonly value: E) {}
     type = 'failure' as const
     isSuccess(): this is Success<T, E> {

--- a/src/errorTypes/resultType.ts
+++ b/src/errorTypes/resultType.ts
@@ -1,0 +1,23 @@
+type Result<T, E> = Success<T, E> | Failure<T, E>
+
+class Success<T, E> {
+    constructor(readonly value: T) {}
+    type = 'success' as const
+    isSuccess(): this is Success<T, E> {
+        return true
+    }
+    isFailure(): this is Failure<T, E> {
+        return false
+    }
+}
+
+class Failure<T, E> {
+    constructor(readonly value: E) {}
+    type = 'failure' as const
+    isSuccess(): this is Success<T, E> {
+        return false
+    }
+    isFailure(): this is Failure<T, E> {
+        return true
+    }
+}

--- a/src/infra/repository/users.ts
+++ b/src/infra/repository/users.ts
@@ -6,11 +6,17 @@ export class usersInfra implements Repository {
         return prisma.user.findMany()
     };
 
-    Get = async (prisma: PrismaClient, userID: number): Promise<User | null> => {
-        return await prisma.user.findUnique({
+    Get = async (prisma: PrismaClient, userID: number): Promise<Result<User, notfoundError>> => {
+        const data = await prisma.user.findUnique({
             where: {
                 id: userID,
             },
         })
+        if (data != null) {
+            return new Success(data);
+        }
+        else {
+            return new Failure(new notfoundError);
+        }
     }
 }

--- a/src/infra/repository/users.ts
+++ b/src/infra/repository/users.ts
@@ -6,7 +6,7 @@ export class usersInfra implements Repository {
         return prisma.user.findMany()
     };
 
-    Get = async (prisma: PrismaClient, userID: number): Promise<Result<User, notfoundError>> => {
+    Get = async (prisma: PrismaClient, userID: number): Promise<Result<User, resourceNotFoundError>> => {
         const data = await prisma.user.findUnique({
             where: {
                 id: userID,
@@ -16,7 +16,7 @@ export class usersInfra implements Repository {
             return new Success(data);
         }
         else {
-            return new Failure(new notfoundError);
+            return new Failure(new resourceNotFoundError("memoID: " + String(userID)));
         }
     }
 }

--- a/src/infra/repository/users.ts
+++ b/src/infra/repository/users.ts
@@ -1,11 +1,20 @@
 import {Repository, user as userDomain} from "../../domain/users";
-import {PrismaClient, User} from "@prisma/client";
+import {PrismaClient} from "@prisma/client";
 import {Failure, Result, Success} from "../../errorTypes/resultType";
 import {resourceNotFoundError} from "../../errorTypes/errors";
 
 export class usersInfra implements Repository {
-    GetList = async (prisma: PrismaClient): Promise<User[]> => {
-        return prisma.user.findMany()
+    GetList = async (prisma: PrismaClient): Promise<userDomain[]> => {
+        const rowData = await prisma.user.findMany()
+        let resData: userDomain[] = [];
+        for (let Key in rowData) {
+            resData.push({
+                ID: rowData[Key].id,
+                email: rowData[Key].email,
+                name: rowData[Key].name
+            })
+        }
+        return resData;
     };
 
     Get = async (prisma: PrismaClient, userID: number): Promise<Result<userDomain, resourceNotFoundError>> => {

--- a/src/infra/repository/users.ts
+++ b/src/infra/repository/users.ts
@@ -1,4 +1,4 @@
-import {Repository} from "../../domain/users";
+import {Repository, user as userDomain} from "../../domain/users";
 import {PrismaClient, User} from "@prisma/client";
 import {Failure, Result, Success} from "../../errorTypes/resultType";
 import {resourceNotFoundError} from "../../errorTypes/errors";
@@ -8,7 +8,7 @@ export class usersInfra implements Repository {
         return prisma.user.findMany()
     };
 
-    Get = async (prisma: PrismaClient, userID: number): Promise<Result<User, resourceNotFoundError>> => {
+    Get = async (prisma: PrismaClient, userID: number): Promise<Result<userDomain, resourceNotFoundError>> => {
         const data = await prisma.user.findUnique({
             where: {
                 id: userID,

--- a/src/infra/repository/users.ts
+++ b/src/infra/repository/users.ts
@@ -5,4 +5,12 @@ export class usersInfra implements Repository {
     GetList = async (prisma: PrismaClient): Promise<User[]> => {
         return prisma.user.findMany()
     };
+
+    Get = async (prisma: PrismaClient, userID: number): Promise<Promise<User> | null> => {
+        return await prisma.user.findUnique({
+            where: {
+                id: userID,
+            },
+        })
+    }
 }

--- a/src/infra/repository/users.ts
+++ b/src/infra/repository/users.ts
@@ -6,7 +6,7 @@ export class usersInfra implements Repository {
         return prisma.user.findMany()
     };
 
-    Get = async (prisma: PrismaClient, userID: number): Promise<Promise<User> | null> => {
+    Get = async (prisma: PrismaClient, userID: number): Promise<User | null> => {
         return await prisma.user.findUnique({
             where: {
                 id: userID,

--- a/src/infra/repository/users.ts
+++ b/src/infra/repository/users.ts
@@ -9,16 +9,22 @@ export class usersInfra implements Repository {
     };
 
     Get = async (prisma: PrismaClient, userID: number): Promise<Result<userDomain, resourceNotFoundError>> => {
-        const data = await prisma.user.findUnique({
+        const rowData = await prisma.user.findUnique({
             where: {
                 id: userID,
             },
         })
-        if (data != null) {
-            return new Success(data);
+        if (rowData == null) {
+            return new Failure(new resourceNotFoundError("memoID: " + String(userID)));
         }
         else {
-            return new Failure(new resourceNotFoundError("memoID: " + String(userID)));
+            // return new Success(rowData);
+            const resData:userDomain = {
+                ID: rowData.id,
+                email: rowData.email,
+                name: rowData.name
+            }
+            return new Success(resData);
         }
     }
 }

--- a/src/infra/repository/users.ts
+++ b/src/infra/repository/users.ts
@@ -1,5 +1,7 @@
 import {Repository} from "../../domain/users";
 import {PrismaClient, User} from "@prisma/client";
+import {Failure, Result, Success} from "../../errorTypes/resultType";
+import {resourceNotFoundError} from "../../errorTypes/errors";
 
 export class usersInfra implements Repository {
     GetList = async (prisma: PrismaClient): Promise<User[]> => {

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -21,6 +21,7 @@ export default function usersRouter(s:Service):express.Router {
     s.users.GetList().then(r => res.json(r));
   });
 
+  // TODO Getのドキュメント書く
   router.get('/:id',(req: express.Request, res: express.Response)=> {
     s.users.Get(req, res);
   })

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -18,7 +18,7 @@ export default function usersRouter(s:Service):express.Router {
   // GETリクエスト
   router.get('/', (req: express.Request, res: express.Response) => {
     // res.status(200).json({ userId: "U001", userName: "Yamada Taro" });
-    s.users.GetList().then(r => res.json(r));
+    s.users.GetList(req, res);
   });
 
   /**
@@ -53,7 +53,6 @@ export default function usersRouter(s:Service):express.Router {
    *       400:
    *        description: Bad request
    */
-
   // POSTリクエスト
   router.post('/', (req: express.Request, res: express.Response) => {
     res.status(200).json({ message: "登録しました" });

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -21,7 +21,21 @@ export default function usersRouter(s:Service):express.Router {
     s.users.GetList().then(r => res.json(r));
   });
 
-  // TODO Getのドキュメント書く
+  /**
+   * @swagger
+   * /user/:id:
+   *  get:
+   *    tags: [User]
+   *    summary: ユーザー詳細取得
+   *    description: Get user info
+   *    response:
+   *      200:
+   *        description: Success
+   *        content: application/json
+   *      400:
+   *        description: Resource not found error
+   *        content: application/json
+   */
   router.get('/:id',(req: express.Request, res: express.Response)=> {
     s.users.Get(req, res);
   })
@@ -46,5 +60,3 @@ export default function usersRouter(s:Service):express.Router {
   });
   return router;
 }
-
-

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -20,6 +20,11 @@ export default function usersRouter(s:Service):express.Router {
     // res.status(200).json({ userId: "U001", userName: "Yamada Taro" });
     s.users.GetList().then(r => res.json(r));
   });
+
+  router.get('/:id',(req: express.Request, res: express.Response)=> {
+    s.users.Get(req, res);
+  })
+
   /**
    * @swagger
    * /users:

--- a/src/usecase/users/endpoint.ts
+++ b/src/usecase/users/endpoint.ts
@@ -18,8 +18,8 @@ export class usersUsecase implements Interactor {
         this.prisma = prisma
     }
     async GetList(): Promise<ListOutput> {
-        const data = getList(this.prisma, this.repository);
-        return convertListOutput(await data);
+        const data = await getList(this.prisma, this.repository);
+        return convertListOutput(data);
     }
     async Get(input: GetInput): Promise<Result<user, Error>> {
         const data = await get(this.prisma, this.repository, input)

--- a/src/usecase/users/endpoint.ts
+++ b/src/usecase/users/endpoint.ts
@@ -2,6 +2,7 @@ import {convertGetOutput, convertListOutput, ListOutput, user,} from "./output";
 import {PrismaClient} from "@prisma/client";
 import {Repository} from "../../domain/users";
 import {getList, get} from "./logic";
+import {GetInput} from "./input";
 
 export type Interactor = {
     GetList(): Promise<ListOutput>;

--- a/src/usecase/users/endpoint.ts
+++ b/src/usecase/users/endpoint.ts
@@ -1,10 +1,11 @@
-import {convertListOutput, ListOutput,} from "./output";
+import {convertGetOutput, convertListOutput, ListOutput, user,} from "./output";
 import {PrismaClient} from "@prisma/client";
 import {Repository} from "../../domain/users";
-import {getList} from "./logic";
+import {getList, get} from "./logic";
 
 export type Interactor = {
-    GetList(): Promise<ListOutput>
+    GetList(): Promise<ListOutput>;
+    Get(input: GetInput): Promise<Result<user, Error>>;
 }
 
 export class usersUsecase implements Interactor {
@@ -17,5 +18,13 @@ export class usersUsecase implements Interactor {
     async GetList(): Promise<ListOutput> {
         const data = getList(this.prisma, this.repository);
         return convertListOutput(await data);
+    }
+    async Get(input: GetInput): Promise<Result<user, Error>> {
+        const data = await get(this.prisma, this.repository, input)
+        if (data.isFailure()) {
+            return new Failure(data.value);
+        } else {
+            return new Success(convertGetOutput(data.value));
+        }
     }
 }

--- a/src/usecase/users/endpoint.ts
+++ b/src/usecase/users/endpoint.ts
@@ -3,6 +3,7 @@ import {PrismaClient} from "@prisma/client";
 import {Repository} from "../../domain/users";
 import {getList, get} from "./logic";
 import {GetInput} from "./input";
+import {Failure, Result, Success} from "../../errorTypes/resultType";
 
 export type Interactor = {
     GetList(): Promise<ListOutput>;

--- a/src/usecase/users/input.ts
+++ b/src/usecase/users/input.ts
@@ -1,0 +1,3 @@
+type GetInput = {
+    userID: number
+}

--- a/src/usecase/users/input.ts
+++ b/src/usecase/users/input.ts
@@ -1,3 +1,3 @@
-type GetInput = {
+export type GetInput = {
     userID: number
 }

--- a/src/usecase/users/logic.ts
+++ b/src/usecase/users/logic.ts
@@ -1,14 +1,14 @@
-import {Repository} from "../../domain/users";
+import {Repository, user as userDomain} from "../../domain/users";
 import {PrismaClient, User} from "@prisma/client";
 import {GetInput} from "./input";
 import {Failure, Result, Success} from "../../errorTypes/resultType";
 
 
-export async function getList(prisma: PrismaClient, userRepo: Repository):Promise<User[]> {
+export async function getList(prisma: PrismaClient, userRepo: Repository):Promise<userDomain[]> {
     return await userRepo.GetList(prisma);
 }
 
-export async function get(prisma: PrismaClient, userRepo: Repository, input: GetInput):Promise<Result<User, Error>> {
+export async function get(prisma: PrismaClient, userRepo: Repository, input: GetInput):Promise<Result<userDomain, Error>> {
     const data = await userRepo.Get(prisma, input.userID);
     if (data.isFailure()) {
         return new Failure(data.value);

--- a/src/usecase/users/logic.ts
+++ b/src/usecase/users/logic.ts
@@ -1,17 +1,15 @@
 import {Repository} from "../../domain/users";
 import {PrismaClient, User} from "@prisma/client";
-import {convertGetOutput, user} from "./output";
 
 export async function getList(prisma: PrismaClient, userRepo: Repository):Promise<User[]> {
     return await userRepo.GetList(prisma);
 }
 
-export async function get(prisma: PrismaClient, userRepo: Repository, input: GetInput):Promise<Result<user, Error>> {
+export async function get(prisma: PrismaClient, userRepo: Repository, input: GetInput):Promise<Result<User, Error>> {
     const data = await userRepo.Get(prisma, input.userID);
     if (data.isFailure()) {
         return new Failure(data.value);
     } else {
-        const convertedData = convertGetOutput(data.value);
-        return new Success(convertedData);
+        return new Success(data.value);
     }
 }

--- a/src/usecase/users/logic.ts
+++ b/src/usecase/users/logic.ts
@@ -1,6 +1,8 @@
 import {Repository} from "../../domain/users";
 import {PrismaClient, User} from "@prisma/client";
 import {GetInput} from "./input";
+import {Failure, Result, Success} from "../../errorTypes/resultType";
+
 
 export async function getList(prisma: PrismaClient, userRepo: Repository):Promise<User[]> {
     return await userRepo.GetList(prisma);

--- a/src/usecase/users/logic.ts
+++ b/src/usecase/users/logic.ts
@@ -1,6 +1,17 @@
 import {Repository} from "../../domain/users";
 import {PrismaClient, User} from "@prisma/client";
+import {convertGetOutput, user} from "./output";
 
 export async function getList(prisma: PrismaClient, userRepo: Repository):Promise<User[]> {
     return await userRepo.GetList(prisma);
+}
+
+export async function get(prisma: PrismaClient, userRepo: Repository, input: GetInput):Promise<Result<user, Error>> {
+    const data = await userRepo.Get(prisma, input.userID);
+    if (data.isFailure()) {
+        return new Failure(data.value);
+    } else {
+        const convertedData = convertGetOutput(data.value);
+        return new Success(convertedData);
+    }
 }

--- a/src/usecase/users/logic.ts
+++ b/src/usecase/users/logic.ts
@@ -1,5 +1,6 @@
 import {Repository} from "../../domain/users";
 import {PrismaClient, User} from "@prisma/client";
+import {GetInput} from "./input";
 
 export async function getList(prisma: PrismaClient, userRepo: Repository):Promise<User[]> {
     return await userRepo.GetList(prisma);

--- a/src/usecase/users/output.ts
+++ b/src/usecase/users/output.ts
@@ -1,4 +1,5 @@
 import {User} from "@prisma/client"
+import {user as userDomain} from "../../domain/users";
 
 export type user = {
     ID: number
@@ -10,15 +11,15 @@ export type ListOutput = {
     users: user[]
 }
 
-export function convertGetOutput(input: User):user{
+export function convertGetOutput(input: userDomain):user{
     return {
-        ID: input.id,
+        ID: input.ID,
         name: input.name,
         email: input.email
     }
 }
 
-export function convertListOutput(input: User[]): ListOutput {
+export function convertListOutput(input: userDomain[]): ListOutput {
     let output: ListOutput;
     output = {
         users: []

--- a/src/usecase/users/output.ts
+++ b/src/usecase/users/output.ts
@@ -1,6 +1,6 @@
 import {User} from "@prisma/client"
 
-type user = {
+export type user = {
     ID: number
     email: string
     name: string | null

--- a/swagger.json
+++ b/swagger.json
@@ -63,6 +63,25 @@
           }
         }
       }
+    },
+    "/user/:id": {
+      "get": {
+        "tags": [
+          "User"
+        ],
+        "summary": "ユーザー詳細取得",
+        "description": "Get user info",
+        "response": {
+          "200": {
+            "description": "Success",
+            "content": "application/json"
+          },
+          "400": {
+            "description": "Resource not found error",
+            "content": "application/json"
+          }
+        }
+      }
     }
   },
   "definitions": {},


### PR DESCRIPTION
## 変更点
- /user/:id でユーザー個別の情報が取れるようにした
- infra 層でPrismaの型をそのまま返していたので、domainで定義した型に変換してからreturnするようにした
- user GetList がRouterでexpress.res.jsonしていたのでController でresponse するように変更
- GetListのドキュメント書いた